### PR TITLE
fix: Cải thiện UX quiz và layout course card

### DIFF
--- a/css/courses.css
+++ b/css/courses.css
@@ -550,6 +550,8 @@
 /* ===== COMPONENT: COURSE CARD (Thẻ khóa học) ===== */
 
 /* Kiểu dáng tổng thể cho một thẻ (card) */
+/* QUY TẮC 4: min-width đủ lớn để chứa "Điểm cao nhất: 100/100" + nút "Làm quiz" trên 1 hàng */
+/* Tính toán: padding (1.5rem x 2 = 3rem) + text (~180px) + gap (0.75rem) + nút (~120px) = ~330px */
 .course-card {
   background-color: var(--color-surface);
   border: 1px solid var(--color-border);
@@ -558,6 +560,7 @@
   cursor: pointer;
   display: flex;
   flex-direction: column;
+  min-width: 330px; /* QUY TẮC 4: Đủ rộng để chứa footer trên 1 hàng */
   overflow: hidden;
   transition: transform var(--transition-base), box-shadow var(--transition-base);
 }
@@ -590,9 +593,11 @@
 }
 
 /* Phần thân (body) chứa nội dung text của card */
+/* QUY TẮC 1: flex-grow: 1 để đẩy footer xuống đáy card */
 .course-card__body {
   display: flex;
   flex-direction: column;
+  flex-grow: 1; /* Đẩy footer xuống dưới cùng để các nút căn thẳng hàng */
   padding: 1.5rem;
 }
 
@@ -673,19 +678,22 @@ body.dark .course-card__badge--upcoming {
 }
 
 /* Phần chân (footer) của card (chứa điểm và nút) */
+/* QUY TẮC 2 & 3: flex-wrap: nowrap để không bao giờ xuống dòng, căn lề 2 phía */
 .course-card__footer {
   align-items: center;
   display: flex;
+  flex-wrap: nowrap; /* QUY TẮC 2: Không bao giờ xuống dòng */
   gap: 0.75rem;
-  justify-content: space-between;
   margin-top: auto; /* Đẩy footer xuống cuối card */
 }
 
 /* Text hiển thị điểm cao nhất */
+/* QUY TẮC 3: white-space: nowrap để text không tự vỡ, căn lề trái */
 .course-card__best-score {
   color: var(--color-accent);
   font-size: 0.95rem;
   font-weight: 600;
+  white-space: nowrap; /* QUY TẮC 3: Giữ chữ không tự vỡ, căn lề trái */
 }
 
 /* Text ghi chú (sắp ra mắt) */
@@ -695,8 +703,10 @@ body.dark .course-card__badge--upcoming {
   font-style: italic;
 }
 
+/* QUY TẮC 3: margin-left: auto để đẩy nút về lề phải */
 .course-card__actions {
-  flex-shrink: 0;
+  flex-shrink: 0; /* Nút không được co lại */
+  margin-left: auto; /* QUY TẮC 3: Tự động chiếm không gian trống, đẩy nút về lề phải */
 }
 
 /* Nút 'Làm quiz' */
@@ -750,11 +760,21 @@ body.dark .course-card__badge--upcoming {
   .course-list {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
+  
+  /* QUY TẮC 4: Trên tablet vẫn phải đảm bảo min-width để footer không vỡ */
+  .course-card {
+    min-width: 330px;
+  }
 }
 
 /* Responsive: Chia 3 cột cho màn hình > 1024px (Desktop) */
 @media (min-width: 1024px) {
   .course-list {
     grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+  
+  /* QUY TẮC 4: Trên desktop vẫn phải đảm bảo min-width để footer không vỡ */
+  .course-card {
+    min-width: 330px;
   }
 }

--- a/css/quiz.css
+++ b/css/quiz.css
@@ -29,7 +29,13 @@
   gap: 2rem;
 }
 
-/* Note: Khi chỉ có 1 card thì canh giữa theo chiều ngang */
+/* Note: Khi chỉ có quiz card (đang làm quiz), căn giữa và làm card rộng hơn */
+.quiz-wrapper--quiz-only {
+  display: flex;
+  justify-content: center;
+}
+
+/* Note: Khi chỉ có 1 card (kết quả) thì canh giữa theo chiều ngang */
 .quiz-wrapper--single {
   display: flex;
   justify-content: center;
@@ -46,6 +52,12 @@
   transition: transform var(--transition-base);
 }
 
+/* Note: Khi quiz card đứng một mình (không có kết quả bên cạnh), làm nó rộng hơn để dễ đọc */
+.quiz-wrapper--quiz-only .quiz-card {
+  max-width: 700px;
+  width: 100%;
+}
+
 .quiz-card__meta {
   align-items: center;
   display: flex;
@@ -53,11 +65,14 @@
   margin-bottom: 1.5rem;
 }
 
-/* Note: Dòng progress/score mờ để không lấn át câu hỏi */
+/* Note: Làm nổi bật thông tin tiến độ để người dùng dễ theo dõi */
 .quiz-card__progress,
 .quiz-card__score {
-  color: var(--color-text-muted);
-  font-size: 0.9rem;
+  color: var(--color-text);
+  font-size: 1.1rem;
+  font-weight: 600;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid var(--color-border);
 }
 
 /* Note: Font đậm giúp câu hỏi là trọng tâm */
@@ -211,12 +226,18 @@
 }
 
 /* Note: Kết quả thiết kế dạng card trung tâm */
+/* Note: Ẩn mặc định khi đang làm quiz, chỉ hiện khi hoàn thành */
 .quiz-result {
   align-items: center;
-  display: flex;
+  display: none;
   flex-direction: column;
   gap: 0.75rem;
   text-align: center;
+}
+
+/* Note: Hiển thị khi quiz hoàn thành */
+.quiz-result--visible {
+  display: flex;
 }
 
 .quiz-result__title {
@@ -321,20 +342,37 @@ body.dark .quiz-option-btn--correct {
 
 /* ===== RESPONSIVE ===== */
 @media (min-width: 768px) {
-  /* Note: Từ tablet trở lên bật 2 cột: câu hỏi + bảng kết quả */
-  .quiz-wrapper {
+  /* Note: Từ tablet trở lên bật 2 cột: câu hỏi + bảng kết quả (chỉ khi có cả 2) */
+  .quiz-wrapper:not(.quiz-wrapper--quiz-only):not(.quiz-wrapper--single) {
     grid-template-columns: minmax(0, 1fr) 360px;
     align-items: start;
   }
 
-  /* Note: Card kết quả giữ vị trí khi cuộn */
-  .quiz-result {
+  /* Note: Card kết quả giữ vị trí khi cuộn (chỉ khi hiển thị) */
+  .quiz-result--visible {
     position: sticky;
     top: 120px;
   }
 
+  /* Note: Khi chỉ có quiz card, căn giữa và giới hạn độ rộng */
+  .quiz-wrapper--quiz-only {
+    display: flex;
+    justify-content: center;
+  }
+
+  .quiz-wrapper--quiz-only .quiz-card {
+    max-width: 700px;
+  }
+
+  /* Note: Khi chỉ có kết quả, căn giữa */
   .quiz-wrapper--single {
     display: flex;
+    justify-content: center;
+  }
+
+  .quiz-wrapper--single .quiz-result {
+    max-width: 500px;
+    width: 100%;
   }
 }
 body.dark .quiz-feedback--wrong {

--- a/js/quiz.js
+++ b/js/quiz.js
@@ -535,9 +535,14 @@ function goToNextQuestion() {
 
 // Kết thúc quiz, cập nhật điểm cao nhất và hiện kết quả
 function finishQuiz() {
+  // Note: Ẩn card câu hỏi và hiển thị ô kết quả
   quizCardElement.hidden = true;
+  if (quizResultElement) {
+    quizResultElement.classList.add("quiz-result--visible");
+  }
   if (quizWrapperElement) {
-    // Note: Khi hoàn thành chỉ còn card kết quả nên ép layout single column
+    // Note: Khi hoàn thành chỉ còn card kết quả, xóa class quiz-only và thêm single
+    quizWrapperElement.classList.remove("quiz-wrapper--quiz-only");
     quizWrapperElement.classList.add("quiz-wrapper--single");
   }
   finalScoreElement.hidden = false;
@@ -573,11 +578,15 @@ function restartQuiz() {
   hasCheckedCurrentQuestion = false;
   inputField = null;
 
+  // Note: Ẩn ô kết quả và hiển thị lại card câu hỏi
+  if (quizResultElement) {
+    quizResultElement.classList.remove("quiz-result--visible");
+  }
   quizCardElement.hidden = false;
-  showInitialResultPanel();
   if (quizWrapperElement) {
-    // Note: Bỏ class single để layout về trạng thái 2 cột như ban đầu
+    // Note: Bỏ class single và thêm quiz-only để căn giữa quiz card
     quizWrapperElement.classList.remove("quiz-wrapper--single");
+    quizWrapperElement.classList.add("quiz-wrapper--quiz-only");
   }
   renderCurrentQuestion();
 }
@@ -634,9 +643,17 @@ document.addEventListener("DOMContentLoaded", () => {
     return;
   }
 
-  // Note: Trình tự khởi tạo: cập nhật tên chủ đề -> hiển thị điểm cao nhất -> render câu đầu
+  // Note: Trình tự khởi tạo: cập nhật tên chủ đề -> đảm bảo ô kết quả bị ẩn -> căn giữa quiz card -> render câu đầu
   updateTopicTitle();
-  showInitialResultPanel();
+  // Note: Đảm bảo ô kết quả bị ẩn khi bắt đầu làm quiz
+  if (quizResultElement) {
+    quizResultElement.classList.remove("quiz-result--visible");
+  }
+  // Note: Thêm class để căn giữa quiz card khi đang làm quiz
+  if (quizWrapperElement) {
+    quizWrapperElement.classList.remove("quiz-wrapper--single");
+    quizWrapperElement.classList.add("quiz-wrapper--quiz-only");
+  }
   renderCurrentQuestion();
 
   checkAnswerButton.addEventListener("click", handleCheckAnswer);


### PR DESCRIPTION
## Mục tiêu
Cải thiện trải nghiệm người dùng trên trang Quiz và trang Khóa học.

## Thay đổi chính

### Quiz Page
- Ẩn ô kết quả khi đang làm quiz để tránh nhầm lẫn
- Căn giữa quiz card khi không có ô kết quả bên cạnh
- Làm nổi bật thông tin tiến độ (Câu hỏi và Điểm)

### Courses Page  
-  Sửa layout footer course card với 4 quy tắc:
- Footer luôn ở đáy card
- Không bao giờ xuống dòng
- Căn lề 2 phía (text trái, nút phải)
- Card có min-width để tránh vỡ layout

## 📝 Files changed
- `css/quiz.css` - Layout và styling cho quiz
- `js/quiz.js` - Logic ẩn/hiện ô kết quả
- `css/courses.css` - Layout footer course card

## 🧪 Testing
- Test trên desktop, tablet, mobile
-  Kiểm tra layout không bị vỡ ở mọi kích thước
-  Đảm bảo footer luôn ở đáy và không xuống dòng